### PR TITLE
sysfs numa distances as costs

### DIFF
--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -21,8 +21,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/docopt/docopt-go"
 	v1alpha1 "github.com/swatisehgal/topologyapi/pkg/apis/topology/v1alpha1"
 	"sigs.k8s.io/node-feature-discovery/pkg/finder"
@@ -87,7 +85,7 @@ func main() {
 			}
 			zones = finder.Aggregate(podResources, nodeResourceData)
 			zonesChannel <- zones
-			log.Printf("After aggregating resources identified zones are:%v", spew.Sdump(zones))
+			log.Printf("After aggregating resources identified zones are:%v", topology.DumpObject(zones))
 
 			time.Sleep(finderArgs.SleepInterval)
 		}

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -594,15 +594,9 @@ func modifyCRD(topoUpdaterZones map[string]*topologypb.Zone) map[string]v1alpha1
 		}
 
 		zones[zoneName] = v1alpha1.Zone{
-			Type:   zone.Type,
-			Parent: zone.Parent,
-			// Costs: updateMap(zone.Costs),
-			// Attributes: updateMap(zone.Attributes),
-			/*
-				Costs: zone.Costs,
-				Attributes: zone.Attributes,
-
-			*/
+			Type:      zone.Type,
+			Parent:    zone.Parent,
+			Costs:     updateMap(zone.Costs),
 			Resources: resInfo,
 		}
 	}

--- a/pkg/nfd-topology-updater/dumpobject.go
+++ b/pkg/nfd-topology-updater/dumpobject.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nfdtopologyupdater
+
+import (
+	"encoding/json"
+)
+
+func DumpObject(obj interface{}) string {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}

--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -25,8 +25,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	v1alpha1 "github.com/swatisehgal/topologyapi/pkg/apis/topology/v1alpha1"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -91,7 +89,7 @@ func NewTopologyUpdater(args Args, policy string) (NfdTopologyUpdater, error) {
 func (w *nfdTopologyUpdater) Update(zones map[string]*v1alpha1.Zone) error {
 	stdoutLogger.Printf("Node Feature Discovery Topology Updater %s", version.Get())
 	stdoutLogger.Printf("NodeName: '%s'", nodeName)
-	stdoutLogger.Printf("Updating now received Zone: '%z'", spew.Sdump(zones))
+	stdoutLogger.Printf("Updating now received Zone: '%s'", DumpObject(zones))
 
 	// Connect to NFD master
 	err := w.connect()
@@ -203,7 +201,7 @@ func advertiseNodeTopology(client pb.NodeTopologyClient, z map[string]*v1alpha1.
 		NodeName:       nodeName,
 		TopologyPolicy: []string{tmPolicy},
 	}
-	stdoutLogger.Printf("Sending NodeTopologyRequest to nfd-master: %v", spew.Sdump(topologyReq))
+	stdoutLogger.Printf("Sending NodeTopologyRequest to nfd-master: %v", DumpObject(topologyReq))
 
 	_, err := client.UpdateNodeTopology(ctx, topologyReq)
 	if err != nil {

--- a/pkg/topologyinfo/numa/distances/distances.go
+++ b/pkg/topologyinfo/numa/distances/distances.go
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package distances
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/node-feature-discovery/pkg/topologyinfo/numa"
+	"sigs.k8s.io/node-feature-discovery/pkg/topologyinfo/sysfs"
+)
+
+const (
+	distanceSeparator string = " "
+)
+
+type nodeDistances struct {
+	values []int
+}
+
+func nodeDistancesFromString(numaNodes int, data string) (nodeDistances, error) {
+	ret := nodeDistances{}
+	dists := strings.Split(data, distanceSeparator)
+	if len(dists) != numaNodes {
+		return ret, fmt.Errorf("found %d distance values, expected %d", len(dists), numaNodes)
+	}
+	ret.values = make([]int, numaNodes, numaNodes)
+	for idx, dist := range dists {
+		val, err := strconv.Atoi(dist)
+		if err != nil {
+			return ret, err
+		}
+		ret.values[idx] = val
+	}
+	return ret, nil
+}
+
+type Distances struct {
+	onlineNodes map[int]bool
+	byNode      []nodeDistances
+}
+
+func (d *Distances) BetweenNodes(from, to int) (int, error) {
+	if _, ok := d.onlineNodes[from]; !ok {
+		return -1, fmt.Errorf("unknown NUMA node: %d", from)
+	}
+	if _, ok := d.onlineNodes[to]; !ok {
+		return -1, fmt.Errorf("unknown NUMA node: %d", to)
+	}
+	return d.byNode[from].values[to], nil
+}
+
+func NewDistancesFromSysfs(sysfsPath string) (*Distances, error) {
+	nodes, err := numa.NewNodesFromSysFS(sysfsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dist := Distances{
+		onlineNodes: make(map[int]bool),
+	}
+
+	sys := sysfs.New(sysfsPath)
+	for _, nodeID := range nodes.Online {
+		dist.onlineNodes[nodeID] = true
+
+		sysNode := sys.ForNode(nodeID)
+		distData, err := sysNode.ReadFile("distance")
+		if err != nil {
+			return nil, err
+		}
+
+		nodeDist, err := nodeDistancesFromString(len(nodes.Online), distData)
+		if err != nil {
+			return nil, err
+		}
+
+		dist.byNode = append(dist.byNode, nodeDist)
+	}
+
+	return &dist, nil
+}

--- a/pkg/topologyinfo/numa/distances/distances_test.go
+++ b/pkg/topologyinfo/numa/distances/distances_test.go
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package distances
+
+import (
+	"testing"
+)
+
+type distTcase struct {
+	Name string
+	From int
+	To   int
+}
+
+func TestDistancesBetweenNodes(t *testing.T) {
+	var err error
+
+	dists := newFakeDistances(map[int]string{
+		0: "10",
+	})
+
+	val, err := dists.BetweenNodes(0, 0)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if val != 10 {
+		t.Errorf("unexpected distance: got %v expected %v", val, 10)
+	}
+
+	for _, tc := range []distTcase{
+		{"unknown to", 0, 1},
+		{"unknown from", 1, 0},
+		{"negative to", 0, -1},
+		{"negative from", -1, 0},
+		{"both unknown", 255, 255},
+		{"both negative", -1, -1},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			if _, err = dists.BetweenNodes(tc.From, tc.To); err == nil {
+				t.Errorf("got distance between unknown nodes: %d, %d", tc.From, tc.To)
+			}
+
+		})
+	}
+
+}
+
+func newFakeDistances(data map[int]string) *Distances {
+	dist := Distances{
+		onlineNodes: make(map[int]bool),
+	}
+	nodeNum := len(data)
+	for nodeID, distData := range data {
+		dist.onlineNodes[nodeID] = true
+		nodeDist, _ := nodeDistancesFromString(nodeNum, distData)
+		dist.byNode = append(dist.byNode, nodeDist)
+	}
+	return &dist
+}

--- a/pkg/topologyinfo/numa/numa.go
+++ b/pkg/topologyinfo/numa/numa.go
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package numa
+
+import (
+	"sigs.k8s.io/node-feature-discovery/pkg/topologyinfo/sysfs"
+)
+
+type Nodes struct {
+	Online           []int
+	Possible         []int
+	WithCPU          []int
+	WithMemory       []int
+	WithNormalMemory []int
+}
+
+func NewNodesFromSysFS(sysfsPath string) (Nodes, error) {
+	sysNode := sysfs.New(sysfsPath).Join(sysfs.PathDevsSysNode)
+
+	online, err := sysNode.ReadList("online")
+	if err != nil {
+		return Nodes{}, err
+	}
+	possible, err := sysNode.ReadList("possible")
+	if err != nil {
+		return Nodes{}, err
+	}
+	hasCPU, err := sysNode.ReadList("has_cpu")
+	if err != nil {
+		return Nodes{}, err
+	}
+	hasMemory, err := sysNode.ReadList("has_memory")
+	if err != nil {
+		return Nodes{}, err
+	}
+	hasNormalMemory, err := sysNode.ReadList("has_normal_memory")
+	if err != nil {
+		return Nodes{}, err
+	}
+
+	return Nodes{
+		Online:           online,
+		Possible:         possible,
+		WithCPU:          hasCPU,
+		WithMemory:       hasMemory,
+		WithNormalMemory: hasNormalMemory,
+	}, nil
+}

--- a/pkg/topologyinfo/sysfs/sysfs.go
+++ b/pkg/topologyinfo/sysfs/sysfs.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fromanirh/cpuset"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 /*
@@ -63,7 +63,11 @@ func (p Path) ReadList(name string) ([]int, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cpuset.Parse(data)
+	cpus, err := cpuset.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	return cpus.ToSlice(), nil
 }
 
 func (p Path) ForNode(nodeID int) Path {

--- a/pkg/topologyinfo/sysfs/sysfs.go
+++ b/pkg/topologyinfo/sysfs/sysfs.go
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package sysfs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/fromanirh/cpuset"
+)
+
+/*
+ * keep this handy:
+ * https://www.kernel.org/doc/html/latest/admin-guide/cputopology.html
+ */
+const (
+	PathDevsSysCPU  = "devices/system/cpu"
+	PathDevsSysNode = "devices/system/node"
+)
+
+type Path struct {
+	base string
+}
+
+func New(base string) Path {
+	return Path{
+		base: base,
+	}
+}
+
+func (p Path) Join(extra string) Path {
+	return Path{
+		base: filepath.Join(p.base, extra),
+	}
+}
+
+func (p Path) ReadFile(name string) (string, error) {
+	data, err := ioutil.ReadFile(filepath.Join(p.base, name))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func (p Path) ReadList(name string) ([]int, error) {
+	data, err := p.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+	return cpuset.Parse(data)
+}
+
+func (p Path) ForNode(nodeID int) Path {
+	return Path{
+		base: filepath.Join(p.base, PathDevsSysNode, fmt.Sprintf("node%d", nodeID)),
+	}
+}
+
+func (p Path) ForCPU(cpuID int) Path {
+	return Path{
+		base: filepath.Join(p.base, PathDevsSysCPU, fmt.Sprintf("cpu%d", cpuID)),
+	}
+}


### PR DESCRIPTION
We need to fill the NUMA zone cost information.
We start using NUMA distances, as reported by linux sysfs, as costs.

Test PR to check the waters, intended to be used mostly as conversation starter to evaluate the approach.

Once we get agreement about the important topics I will either polish up this PR or file a cleaner new one.

There are a number of design decisions to discuss:
1. are we happy with minimal code to read directly from sysfs?
   do we want to introduce/depend on an external package?
   please not cadvisor doesn't seem to report NUMA distances/costs
   (yet?)
2. Who do we make sure we reconcile properly the NUMA zones from
   podresources to sysfs?
3. (minor, but still) why do topologyapi and the internal protocol
   use slightly different types (e.g int vs int32)? can we get
   uniformity?
4. do we want a deeper refactoring of `pkg/finder`?