### PR TITLE
Testing Topology updater in NFD

### DIFF
--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -146,9 +146,12 @@ func argsParse(argv []string) (topology.Args, finder.Args, error) {
                                   value implies no re-labeling (i.e. infinite
                                   sleep). [Default: 60s]
   --watch-namespace=<namespace>   Namespace to watch pods for. Use "" for all namespaces.
-  --sysfs=<mountpoint>            Mount point of the sysfs. [Default: /host-sys]
-  --kubelet-config-file=<path>    Kubelet config file path. [Default: /host-etc/kubernetes/kubelet.conf]
-  --podresources-socket=<path>    Pod Resource Socket path to use. `,
+  --sysfs=<mountpoint>            Mount point of the sysfs.
+                                  [Default: /host-sys]
+  --kubelet-config-file=<path>    Kubelet config file path.
+                                  [Default: /podresources/config.yaml]
+  --podresources-socket=<path>    Pod Resource Socket path to use.
+                                  [Default: /podresources/kubelet.sock] `,
 
 		ProgramName,
 		ProgramName,

--- a/cmd/nfd-topology-updater/main_test.go
+++ b/cmd/nfd-topology-updater/main_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestArgsParse(t *testing.T) {
+	Convey("When parsing command line arguments", t, func() {
+		Convey("When --no-publish and --oneshot flags are passed", func() {
+			args, finderArgs, err := argsParse([]string{"--no-publish", "--oneshot"})
+
+			Convey("noPublish is set and args.sources is set to the default value", func() {
+				So(args.NoPublish, ShouldBeTrue)
+				So(args.Oneshot, ShouldBeTrue)
+				So(finderArgs.SleepInterval, ShouldEqual, 60*time.Second)
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sys")
+				So(finderArgs.KubeletConfigFile, ShouldEqual, "/podresources/config.yaml")
+				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/podresources/kubelet.sock")
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When valid args are specified for --kubelet-config-file and --sleep-interval,", func() {
+			args, finderArgs, err := argsParse([]string{"--kubelet-config-file=/path/testconfig.yaml", "--sleep-interval=30s"})
+
+			Convey("args.sources is set to appropriate values", func() {
+				So(args.NoPublish, ShouldBeFalse)
+				So(args.Oneshot, ShouldBeFalse)
+				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sys")
+				So(finderArgs.KubeletConfigFile, ShouldEqual, "/path/testconfig.yaml")
+				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/podresources/kubelet.sock")
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When valid args are specified for --podresources-socket flag and --sleep-interval is specified", func() {
+			args, finderArgs, err := argsParse([]string{"--podresources-socket=/path/testkubelet.sock", "--sleep-interval=30s"})
+
+			Convey("args.sources is set to appropriate values", func() {
+				So(args.NoPublish, ShouldBeFalse)
+				So(args.Oneshot, ShouldBeFalse)
+				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sys")
+				So(finderArgs.KubeletConfigFile, ShouldEqual, "/podresources/config.yaml")
+				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/path/testkubelet.sock")
+				So(err, ShouldBeNil)
+			})
+		})
+		Convey("When valid args are specified for--sysfs and --sleep-inteval is specified", func() {
+			args, finderArgs, err := argsParse([]string{"--sysfs=/host-sysfs", "--sleep-interval=30s"})
+
+			Convey("args.sources is set to appropriate values", func() {
+				So(args.NoPublish, ShouldBeFalse)
+				So(args.Oneshot, ShouldBeFalse)
+				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sysfs")
+				So(finderArgs.KubeletConfigFile, ShouldEqual, "/podresources/config.yaml")
+				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/podresources/kubelet.sock")
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When All valid args are specified", func() {
+			args, finderArgs, err := argsParse([]string{"--no-publish", "--sleep-interval=30s", "--sysfs=/host-sysfs", "--kubelet-config-file=/path/testconfig.yaml", "--podresources-socket=/path/testkubelet.sock", "--ca-file=ca", "--cert-file=crt", "--key-file=key"})
+
+			Convey("--no-publish is set and args.sources is set to appropriate values", func() {
+				So(args.NoPublish, ShouldBeTrue)
+				So(args.CaFile, ShouldEqual, "ca")
+				So(args.CertFile, ShouldEqual, "crt")
+				So(args.KeyFile, ShouldEqual, "key")
+				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sysfs")
+				So(finderArgs.KubeletConfigFile, ShouldEqual, "/path/testconfig.yaml")
+				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/path/testkubelet.sock")
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/nfd-topology-updater-daemonset.yaml
+++ b/nfd-topology-updater-daemonset.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: nfd-worker
+      app: nfd-topology-updater
   template:
     metadata:
       labels:
@@ -35,6 +35,7 @@ spec:
             - "--kubelet-config-file=/podresources/config.yaml"
             - "--podresources-socket=/podresources/kubelet.sock"
             - "--sleep-interval=3s"
+            - "--watch-namespace=rte"
             - "--server=nfd-master:8080"
 ## Enable TLS authentication (1/3)
 ## The example below assumes having the root certificate named ca.crt stored in

--- a/nfd-topology-updater-daemonset.yaml.template
+++ b/nfd-topology-updater-daemonset.yaml.template
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: nfd-worker
+      app: nfd-topology-updater
   template:
     metadata:
       labels:
@@ -35,6 +35,7 @@ spec:
             - "--kubelet-config-file=/podresources/config.yaml"
             - "--podresources-socket=/podresources/kubelet.sock"
             - "--sleep-interval=3s"
+            - "--watch-namespace=rte"
             - "--server=nfd-master:8080"
 ## Enable TLS authentication (1/3)
 ## The example below assumes having the root certificate named ca.crt stored in

--- a/pkg/kubeconf/kubelet_config_file_test.go
+++ b/pkg/kubeconf/kubelet_config_file_test.go
@@ -13,7 +13,7 @@ type testCaseData struct {
 func TestGetKubeletConfigFromLocalFile(t *testing.T) {
 	tCases := []testCaseData{
 		{
-			path:     filepath.Join("..", "..", "config", "examples", "kubeletconf.yaml"),
+			path:     filepath.Join("..", "..", "test", "data", "kubeletconf.yaml"),
 			tmPolicy: "single-numa-node",
 		},
 	}

--- a/pkg/nfd-topology-updater/nfd-topology-updater_test.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nfdtopologyupdater_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	v1alpha1 "github.com/swatisehgal/topologyapi/pkg/apis/topology/v1alpha1"
+	nfdmaster "sigs.k8s.io/node-feature-discovery/pkg/nfd-master"
+	u "sigs.k8s.io/node-feature-discovery/pkg/nfd-topology-updater"
+	"sigs.k8s.io/node-feature-discovery/test/data"
+)
+
+type testContext struct {
+	master nfdmaster.NfdMaster
+	errs   chan error
+}
+
+func setupTest(args nfdmaster.Args) testContext {
+	// Fixed port and no-publish, for convenience
+	args.NoPublish = true
+	args.Port = 8192
+	m, err := nfdmaster.NewNfdMaster(args)
+	if err != nil {
+		fmt.Printf("Test setup failed: %v\n", err)
+		os.Exit(1)
+	}
+	ctx := testContext{master: m, errs: make(chan error)}
+
+	// Run nfd-master instance, intended to be used as the server counterpart
+	go func() {
+		ctx.errs <- ctx.master.Run()
+		close(ctx.errs)
+	}()
+	ready := ctx.master.WaitForReady(time.Second)
+	if !ready {
+		fmt.Println("Test setup failed: timeout while waiting for nfd-master")
+		os.Exit(1)
+	}
+
+	return ctx
+}
+
+func teardownTest(ctx testContext) {
+	ctx.master.Stop()
+	for e := range ctx.errs {
+		if e != nil {
+			fmt.Printf("Error in test context: %v\n", e)
+			os.Exit(1)
+		}
+	}
+}
+
+func TestNewTopologyUpdater(t *testing.T) {
+	Convey("When initializing new NfdTopologyUpdater instance", t, func() {
+		Convey("When one of --cert-file, --key-file or --ca-file is missing", func() {
+			tmPolicy := "fake-topology-manager-policy"
+			_, err := u.NewTopologyUpdater(u.Args{CertFile: "crt", KeyFile: "key"}, tmPolicy)
+			_, err2 := u.NewTopologyUpdater(u.Args{KeyFile: "key", CaFile: "ca"}, tmPolicy)
+			_, err3 := u.NewTopologyUpdater(u.Args{CertFile: "crt", CaFile: "ca"}, tmPolicy)
+			Convey("An error should be returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err2, ShouldNotBeNil)
+				So(err3, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	ctx := setupTest(nfdmaster.Args{})
+	resourceInfo := v1alpha1.ResourceInfoMap{"cpu": v1alpha1.ResourceInfo{Allocatable: "2", Capacity: "4"}}
+	z := &v1alpha1.Zone{
+		Type:      "Node",
+		Resources: resourceInfo,
+	}
+	zones := map[string]*v1alpha1.Zone{"node-0": z}
+	defer teardownTest(ctx)
+	Convey("When running nfd-topology-updater against nfd-master", t, func() {
+		Convey("When running as a Oneshot job with Zones", func() {
+			updater, _ := u.NewTopologyUpdater(u.Args{Oneshot: true, Server: "localhost:8192"}, "fake-topology-manager-policy")
+			err := updater.Update(zones)
+			Convey("No error should be returned", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestRunTls(t *testing.T) {
+	masterArgs := nfdmaster.Args{
+		CaFile:         data.FilePath("ca.crt"),
+		CertFile:       data.FilePath("nfd-test-master.crt"),
+		KeyFile:        data.FilePath("nfd-test-master.key"),
+		VerifyNodeName: false,
+	}
+	ctx := setupTest(masterArgs)
+	defer teardownTest(ctx)
+	Convey("When running nfd-worker against nfd-master with mutual TLS auth enabled", t, func() {
+		Convey("When publishing CRDs obtained from Zones", func() {
+			resourceInfo := v1alpha1.ResourceInfoMap{"cpu": v1alpha1.ResourceInfo{Allocatable: "2", Capacity: "4"}}
+			z := &v1alpha1.Zone{
+				Type:      "Node",
+				Resources: resourceInfo,
+			}
+			zones := map[string]*v1alpha1.Zone{"node-0": z}
+			updaterArgs := u.Args{
+				CaFile:             data.FilePath("ca.crt"),
+				CertFile:           data.FilePath("nfd-test-topology-updater.crt"),
+				KeyFile:            data.FilePath("nfd-test-topology-updater.key"),
+				Oneshot:            true,
+				Server:             "localhost:8192",
+				ServerNameOverride: "nfd-test-master"}
+			updater, _ := u.NewTopologyUpdater(updaterArgs, "fake-topology-manager-policy")
+			err := updater.Update(zones)
+			Convey("No error should be returned", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/test/data/kubeletconf.yaml
+++ b/test/data/kubeletconf.yaml
@@ -1,0 +1,42 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 0s
+    enabled: true
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 0s
+    cacheUnauthorizedTTL: 0s
+clusterDNS:
+- 10.96.0.10
+clusterDomain: cluster.local
+cpuManagerPolicy: static
+cpuManagerReconcilePeriod: 0s
+evictionHard:
+  imagefs.available: 0%
+  nodefs.available: 0%
+  nodefs.inodesFree: 0%
+evictionPressureTransitionPeriod: 0s
+fileCheckFrequency: 0s
+healthzBindAddress: 127.0.0.1
+healthzPort: 10248
+httpCheckFrequency: 0s
+imageGCHighThresholdPercent: 100
+imageMinimumGCAge: 0s
+kind: KubeletConfiguration
+logging: {}
+nodeStatusReportFrequency: 0s
+nodeStatusUpdateFrequency: 0s
+reservedSystemCPUs: 1,3
+rotateCertificates: true
+runtimeRequestTimeout: 0s
+staticPodPath: /etc/kubernetes/manifests
+streamingConnectionIdleTimeout: 0s
+syncFrequency: 0s
+topologyManagerPolicy: single-numa-node
+volumeStatsAggPeriod: 0s


### PR DESCRIPTION
Topology Updater is a new feature introduced in NFD.
This PR includes:
 

1. Testing nfd-topology-updater_test.go in nfd-topology-updater package

1. Testing kubelet_config_file.go

1. bug fixes in Manifest files

1. Testing Topology updater main.go

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>