### PR TITLE
topologyinfo: add unit tests

### DIFF
--- a/pkg/topologyinfo/numa/distances/distances_test.go
+++ b/pkg/topologyinfo/numa/distances/distances_test.go
@@ -27,11 +27,12 @@ type distTcase struct {
 }
 
 func TestDistancesBetweenNodes(t *testing.T) {
-	var err error
-
-	dists := newFakeDistances(map[int]string{
-		0: "10",
+	dists, err := NewDistancesFromData(map[string]string{
+		"0": "10\n",
 	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	val, err := dists.BetweenNodes(0, 0)
 	if err != nil {
@@ -57,17 +58,4 @@ func TestDistancesBetweenNodes(t *testing.T) {
 		})
 	}
 
-}
-
-func newFakeDistances(data map[int]string) *Distances {
-	dist := Distances{
-		onlineNodes: make(map[int]bool),
-	}
-	nodeNum := len(data)
-	for nodeID, distData := range data {
-		dist.onlineNodes[nodeID] = true
-		nodeDist, _ := nodeDistancesFromString(nodeNum, distData)
-		dist.byNode = append(dist.byNode, nodeDist)
-	}
-	return &dist
 }

--- a/pkg/topologyinfo/numa/numa_test.go
+++ b/pkg/topologyinfo/numa/numa_test.go
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package numa
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	fakesysfs "sigs.k8s.io/node-feature-discovery/pkg/topologyinfo/sysfs/fake"
+)
+
+func TestReadNUMAINfo(t *testing.T) {
+
+	expected := Nodes{
+		Online:           []int{0, 2, 3},
+		Possible:         []int{0, 1, 2, 3},
+		WithCPU:          []int{0, 1},
+		WithMemory:       []int{2, 3},
+		WithNormalMemory: []int{0, 1},
+	}
+
+	data := map[string]string{
+		"online":            "0,2,3",
+		"possible":          "0,1,2,3",
+		"has_cpu":           "0,1",
+		"has_memory":        "2,3",
+		"has_normal_memory": "0,1",
+	}
+
+	base, err := ioutil.TempDir("/tmp", "fakesysfs")
+	if err != nil {
+		t.Errorf("error creating temp base dir: %v", err)
+	}
+	fs, err := fakesysfs.NewFakeSysfs(base)
+	if err != nil {
+		t.Errorf("error creating fakesysfs: %v", err)
+	}
+	t.Logf("sysfs at %q", fs.Base())
+
+	sysDevs := fs.AddTree("sys", "devices")
+	devSys := sysDevs.Add("system", nil)
+	devSys.Add("node", data)
+
+	err = fs.Setup()
+	if err != nil {
+		t.Errorf("error setting up fakesysfs: %v", err)
+	}
+	defer func() {
+		if _, ok := os.LookupEnv("TOPOLOGYINFO_TEST_KEEP_TREE"); ok {
+			t.Logf("found environment variable, keeping fake tree")
+		} else {
+			err = fs.Teardown()
+			if err != nil {
+				t.Errorf("error tearing down fakesysfs: %v", err)
+			}
+		}
+	}()
+
+	info, err := NewNodesFromSysFS(filepath.Join(fs.Base(), "sys"))
+	if err != nil {
+		t.Errorf("error in NewNodesFromSysFS: %v", err)
+	}
+
+	if !reflect.DeepEqual(info, expected) {
+		t.Errorf("data mismatch found %v expected %v", info, expected)
+	}
+}

--- a/pkg/topologyinfo/sysfs/fake/fakesysfs.go
+++ b/pkg/topologyinfo/sysfs/fake/fakesysfs.go
@@ -1,0 +1,174 @@
+package fake
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+type DebugLogger func(string, ...interface{})
+
+func NullDebugLogger(fmt string, args ...interface{}) {
+	return
+}
+
+var DebugLog DebugLogger = NullDebugLogger
+
+type Tree interface {
+	Add(name string, attrs map[string]string) Tree
+	Name() string
+	Items() []Tree
+	SetAttrs() error
+	Attrs() map[string]string
+	Create() error
+}
+
+type Creator interface {
+	Create(Tree) error
+}
+
+func NewTree(name string, attrs map[string]string) Tree {
+	return &tree{
+		name:  name,
+		attrs: attrs,
+		items: []Tree{},
+	}
+}
+
+type tree struct {
+	name  string
+	attrs map[string]string
+	items []Tree
+}
+
+func (t *tree) Add(name string, attrs map[string]string) Tree {
+	n := NewTree(name, attrs)
+	t.items = append(t.items, n)
+	return n
+}
+
+func (t *tree) Items() []Tree {
+	return t.items
+}
+
+func (t *tree) Name() string {
+	return t.name
+}
+
+func (t *tree) Create() error {
+	return newCreator().Create(t)
+}
+
+func (t *tree) Attrs() map[string]string {
+	res := make(map[string]string)
+	for key, val := range t.attrs {
+		res[key] = val
+	}
+	return res
+}
+
+func (t *tree) SetAttrs() error {
+	if t.attrs == nil {
+		DebugLog("%q attrs NONE", t.name)
+		return nil
+	}
+	var err error
+	for name, content := range t.attrs {
+		DebugLog("%q attrs %q", t.name, name)
+		err = ioutil.WriteFile(name, []byte(content), 0644)
+		if err != nil {
+			break
+		}
+	}
+	return err
+}
+
+func MakeAttrs(attrs map[string]string) map[string]string {
+	resAttrs := make(map[string]string)
+	for key, value := range attrs {
+		if strings.HasSuffix(value, "\n") {
+			resAttrs[key] = value
+		} else {
+			resAttrs[key] = value + "\n"
+		}
+	}
+	return resAttrs
+}
+
+type creator struct{}
+
+func newCreator() Creator {
+	return &creator{}
+}
+
+func (c *creator) Create(t Tree) error {
+	DebugLog("%q attrs: %v", t.Name(), t.Attrs())
+	if err := t.SetAttrs(); err != nil {
+		return err
+	}
+	DebugLog("%q items: %v", t.Name(), t.Items())
+	return c.createItems(t.Items())
+}
+
+func (c *creator) createItems(t []Tree) error {
+	var err error
+	for _, st := range t {
+		err = os.Mkdir(st.Name(), 0755)
+		if err != nil {
+			break
+		}
+		err = c.createItem(st)
+	}
+	return err
+}
+
+func (c *creator) createItem(st Tree) error {
+	os.Chdir(st.Name())
+	defer os.Chdir("..")
+	return st.Create()
+}
+
+type FakeSysfs struct {
+	base string
+	root Tree
+}
+
+func NewFakeSysfs(base string) (*FakeSysfs, error) {
+	return &FakeSysfs{
+		base: base,
+		root: NewTree("", nil),
+	}, nil
+}
+
+func (fs *FakeSysfs) AddTree(entries ...string) Tree {
+	DebugLog("%q adding: %v", fs.base, entries)
+	pos := fs.root
+	for _, entry := range entries {
+		pos = pos.Add(entry, nil)
+	}
+	return pos
+}
+
+func (fs *FakeSysfs) Base() string {
+	return fs.base
+}
+
+func (fs *FakeSysfs) Root() Tree {
+	return fs.root
+}
+
+func (fs *FakeSysfs) Setup() error {
+	oldWd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(oldWd)
+	os.Chdir(fs.base)
+	DebugLog("Setup(%q)", fs.base)
+	return fs.root.Create()
+}
+
+func (fs *FakeSysfs) Teardown() error {
+	DebugLog("Teardown(%q)", fs.base)
+	return os.RemoveAll(fs.base)
+}

--- a/pkg/topologyinfo/sysfs/fake/fakesysfs_test.go
+++ b/pkg/topologyinfo/sysfs/fake/fakesysfs_test.go
@@ -1,0 +1,106 @@
+package fake
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"testing"
+)
+
+type devData struct {
+	addr  string
+	attrs map[string]string
+}
+
+func TestPCIDevices(t *testing.T) {
+	DebugLog = log.Printf
+
+	base, err := ioutil.TempDir("/tmp", "fakesysfs")
+	if err != nil {
+		t.Errorf("error creating temp base dir: %v", err)
+	}
+	fs, err := NewFakeSysfs(base)
+	if err != nil {
+		t.Errorf("error creating fakesysfs: %v", err)
+	}
+	t.Logf("sysfs at %q", fs.Base())
+
+	fakeDevs := []devData{
+		{
+			addr: "0000:00:01.0",
+			attrs: map[string]string{
+				"numa_node":     "0\n",
+				"vendor":        "0x8086\n",
+				"device":        "0xcafe\n",
+				"local_cpulist": "0,42\n",
+			},
+		},
+		{
+			addr: "0000:00:02.0",
+			attrs: map[string]string{
+				"numa_node": "1\n",
+			},
+		},
+	}
+
+	devs := fs.AddTree("sys", "bus", "pci", "devices")
+	for _, fakeDev := range fakeDevs {
+		devs.Add(fakeDev.addr, fakeDev.attrs)
+	}
+	err = fs.Setup()
+	if err != nil {
+		t.Errorf("error setting up fakesysfs: %v", err)
+	}
+
+	defer func() {
+		if _, ok := os.LookupEnv("FAKESYS_TEST_KEEP_TREE"); ok {
+			t.Logf("found environment variable, keeping fake tree")
+		} else {
+			err = fs.Teardown()
+			if err != nil {
+				t.Errorf("error tearing down fakesysfs: %v", err)
+			}
+		}
+	}()
+
+	checkPath(t, fakeDevs, filepath.Join(fs.Base(), "sys", "bus", "pci", "devices"))
+}
+
+func checkPath(t *testing.T, fakeDevs []devData, subPath string) {
+	for _, fakeDev := range fakeDevs {
+		devPath := filepath.Join(subPath, fakeDev.addr)
+
+		attrs, err := readNodeAttrs(devPath)
+		if err != nil {
+			t.Errorf("error reading back %q: %v", fakeDev.addr, err)
+		}
+
+		for key, value := range fakeDev.attrs {
+			val, ok := attrs[key]
+			if !ok || val != value {
+				t.Errorf("value mismatch for %q key %q expected %q got %q", fakeDev.addr, key, value, val)
+			}
+		}
+	}
+}
+
+func readNodeAttrs(leafPath string) (map[string]string, error) {
+	files, err := ioutil.ReadDir(leafPath)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := make(map[string]string)
+	for _, f := range files {
+		attrPath := filepath.Join(leafPath, f.Name())
+		data, err := ioutil.ReadFile(attrPath)
+		if err != nil {
+			return attrs, err
+		}
+
+		attrs[f.Name()] = string(data)
+	}
+	return attrs, nil
+}

--- a/pkg/topologyinfo/sysfs/sysfs.go
+++ b/pkg/topologyinfo/sysfs/sysfs.go
@@ -35,23 +35,23 @@ const (
 )
 
 type Path struct {
-	base string
+	path string
 }
 
-func New(base string) Path {
+func New(path string) Path {
 	return Path{
-		base: base,
+		path: path,
 	}
 }
 
-func (p Path) Join(extra string) Path {
+func (p Path) Join(extra ...string) Path {
 	return Path{
-		base: filepath.Join(p.base, extra),
+		path: filepath.Join(p.path, filepath.Join(extra...)),
 	}
 }
 
 func (p Path) ReadFile(name string) (string, error) {
-	data, err := ioutil.ReadFile(filepath.Join(p.base, name))
+	data, err := ioutil.ReadFile(filepath.Join(p.path, name))
 	if err != nil {
 		return "", err
 	}
@@ -71,13 +71,9 @@ func (p Path) ReadList(name string) ([]int, error) {
 }
 
 func (p Path) ForNode(nodeID int) Path {
-	return Path{
-		base: filepath.Join(p.base, PathDevsSysNode, fmt.Sprintf("node%d", nodeID)),
-	}
+	return p.Join(PathDevsSysNode, fmt.Sprintf("node%d", nodeID))
 }
 
 func (p Path) ForCPU(cpuID int) Path {
-	return Path{
-		base: filepath.Join(p.base, PathDevsSysCPU, fmt.Sprintf("cpu%d", cpuID)),
-	}
+	return p.Join(PathDevsSysCPU, fmt.Sprintf("cpu%d", cpuID))
 }

--- a/pkg/topologyinfo/sysfs/sysfs_test.go
+++ b/pkg/topologyinfo/sysfs/sysfs_test.go
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package sysfs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	fakesysfs "sigs.k8s.io/node-feature-discovery/pkg/topologyinfo/sysfs/fake"
+)
+
+func TestReadSingleNuma(t *testing.T) {
+	base, err := ioutil.TempDir("/tmp", "fakesysfs")
+	if err != nil {
+		t.Errorf("error creating temp base dir: %v", err)
+	}
+	fs, err := fakesysfs.NewFakeSysfs(base)
+	if err != nil {
+		t.Errorf("error creating fakesysfs: %v", err)
+	}
+	t.Logf("sysfs at %q", fs.Base())
+
+	allCpus := []int{0, 1, 2, 3, 4, 5, 6, 7}
+	cpuList := "0-7\n"
+
+	sysDevs := fs.AddTree("sys", "devices")
+	devSys := sysDevs.Add("system", nil)
+	devNode := devSys.Add("node", map[string]string{
+		"online": "0",
+	})
+	devNode.Add("node0", map[string]string{
+		"cpulist": cpuList,
+	})
+	devCpu := devSys.Add("cpu", map[string]string{
+		"present": cpuList,
+		"online":  cpuList,
+	})
+	for _, cpuID := range allCpus {
+		devCpu.Add(fmt.Sprintf("cpu%d", cpuID), nil).Add("topology", map[string]string{
+			"thread_siblings_list": cpuList,
+			"core_siblings_list":   cpuList,
+			"physical_package_id":  "0\n",
+		})
+	}
+
+	err = fs.Setup()
+	if err != nil {
+		t.Errorf("error setting up fakesysfs: %v", err)
+	}
+	defer func() {
+		if _, ok := os.LookupEnv("TOPOLOGYINFO_TEST_KEEP_TREE"); ok {
+			t.Logf("found environment variable, keeping fake tree")
+		} else {
+			err = fs.Teardown()
+			if err != nil {
+				t.Errorf("error tearing down fakesysfs: %v", err)
+			}
+		}
+	}()
+
+	sysRoot := filepath.Join(fs.Base(), "sys")
+	foundCpus, err := New(sysRoot).ForNode(0).ReadList("cpulist")
+	if err != nil {
+		t.Errorf("unexpected error reading cpulist for node 0: %v", err)
+	}
+	if !reflect.DeepEqual(foundCpus, allCpus) {
+		t.Errorf("found cpus %v expected %v", foundCpus, allCpus)
+	}
+
+	foundPhysPackageID, err := New(sysRoot).ForCPU(0).Join("topology").ReadFile("physical_package_id")
+	if err != nil {
+		t.Errorf("unexpected error reading physical package id for cpu 0: %v", err)
+	}
+	val := strings.TrimSpace(foundPhysPackageID)
+	if val != "0" {
+		t.Errorf("found physical package id %v expected %v", val, "0")
+	}
+}
+
+func TestReadWrongData(t *testing.T) {
+	base, err := ioutil.TempDir("/tmp", "fakesysfs")
+	if err != nil {
+		t.Errorf("error creating temp base dir: %v", err)
+	}
+	fs, err := fakesysfs.NewFakeSysfs(base)
+	if err != nil {
+		t.Errorf("error creating fakesysfs: %v", err)
+	}
+	t.Logf("sysfs at %q", fs.Base())
+
+	allCpus := []int{0, 1, 2, 3, 4, 5, 6, 7}
+	cpuList := "0-7\n"
+
+	sysDevs := fs.AddTree("sys", "devices")
+	devSys := sysDevs.Add("system", nil)
+	devNode := devSys.Add("node", map[string]string{
+		"online": "0",
+	})
+	devNode.Add("node0", map[string]string{
+		"cpulist": cpuList,
+	})
+	devCpu := devSys.Add("cpu", map[string]string{
+		"present": cpuList,
+		"online":  cpuList,
+	})
+	for _, cpuID := range allCpus {
+		devCpu.Add(fmt.Sprintf("cpu%d", cpuID), nil).Add("topology", map[string]string{
+			"thread_siblings_list": cpuList,
+			"core_siblings_list":   cpuList,
+			"physical_package_id":  "0\n",
+		})
+	}
+
+	err = fs.Setup()
+	if err != nil {
+		t.Errorf("error setting up fakesysfs: %v", err)
+	}
+	defer func() {
+		if _, ok := os.LookupEnv("TOPOLOGYINFO_TEST_KEEP_TREE"); ok {
+			t.Logf("found environment variable, keeping fake tree")
+		} else {
+			err = fs.Teardown()
+			if err != nil {
+				t.Errorf("error tearing down fakesysfs: %v", err)
+			}
+		}
+	}()
+
+	sysRoot := filepath.Join(fs.Base(), "sys")
+	foundCpus, err := New(sysRoot).ForNode(0).ReadList("cpulist")
+	if err != nil {
+		t.Errorf("unexpected error reading cpulist for node 0: %v", err)
+	}
+	if !reflect.DeepEqual(foundCpus, allCpus) {
+		t.Errorf("found cpus %v expected %v", foundCpus, allCpus)
+	}
+
+	_, err = New(sysRoot).ForCPU(0).Join("topology").ReadFile("does_not_exist")
+	if err == nil {
+		t.Errorf("missing expected error reading unexistent file")
+	}
+
+	_, err = New(sysRoot).ForCPU(0).Join("topology").ReadList("does_not_exist")
+	if err == nil {
+		t.Errorf("missing expected error reading unexistent file as list")
+	}
+}


### PR DESCRIPTION
Improve the test coverage
To actually test the sysfs helper package we introduce an
additional subpackage to fake sysfs tree - with its own tests.

Signed-off-by: Francesco Romani <fromani@redhat.com>