### PR TITLE
resourcemonitor: switch to ghw

### DIFF
--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -151,7 +151,7 @@ func argsParse(argv []string) (topology.Args, resourcemonitor.Args, error) {
                                   sleep). [Default: 60s]
   --watch-namespace=<namespace>   Namespace to watch pods for. Use "" for all namespaces.
   --sysfs=<mountpoint>            Mount point of the sysfs.
-                                  [Default: /host-sys]
+                                  [Default: /host]
   --kubelet-config-file=<path>    Kubelet config file path.
                                   [Default: /podresources/config.yaml]
   --podresources-socket=<path>    Pod Resource Socket path to use.

--- a/cmd/nfd-topology-updater/main_test.go
+++ b/cmd/nfd-topology-updater/main_test.go
@@ -32,7 +32,7 @@ func TestArgsParse(t *testing.T) {
 				So(args.NoPublish, ShouldBeTrue)
 				So(args.Oneshot, ShouldBeTrue)
 				So(finderArgs.SleepInterval, ShouldEqual, 60*time.Second)
-				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sys")
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host")
 				So(finderArgs.KubeletConfigFile, ShouldEqual, "/podresources/config.yaml")
 				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/podresources/kubelet.sock")
 				So(err, ShouldBeNil)
@@ -46,7 +46,7 @@ func TestArgsParse(t *testing.T) {
 				So(args.NoPublish, ShouldBeFalse)
 				So(args.Oneshot, ShouldBeFalse)
 				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
-				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sys")
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host")
 				So(finderArgs.KubeletConfigFile, ShouldEqual, "/path/testconfig.yaml")
 				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/podresources/kubelet.sock")
 				So(err, ShouldBeNil)
@@ -60,20 +60,20 @@ func TestArgsParse(t *testing.T) {
 				So(args.NoPublish, ShouldBeFalse)
 				So(args.Oneshot, ShouldBeFalse)
 				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
-				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sys")
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host")
 				So(finderArgs.KubeletConfigFile, ShouldEqual, "/podresources/config.yaml")
 				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/path/testkubelet.sock")
 				So(err, ShouldBeNil)
 			})
 		})
 		Convey("When valid args are specified for--sysfs and --sleep-inteval is specified", func() {
-			args, finderArgs, err := argsParse([]string{"--sysfs=/host-sysfs", "--sleep-interval=30s"})
+			args, finderArgs, err := argsParse([]string{"--sysfs=/host/sysfs-root", "--sleep-interval=30s"})
 
 			Convey("args.sources is set to appropriate values", func() {
 				So(args.NoPublish, ShouldBeFalse)
 				So(args.Oneshot, ShouldBeFalse)
 				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
-				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sysfs")
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host/sysfs-root")
 				So(finderArgs.KubeletConfigFile, ShouldEqual, "/podresources/config.yaml")
 				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/podresources/kubelet.sock")
 				So(err, ShouldBeNil)
@@ -81,7 +81,7 @@ func TestArgsParse(t *testing.T) {
 		})
 
 		Convey("When All valid args are specified", func() {
-			args, finderArgs, err := argsParse([]string{"--no-publish", "--sleep-interval=30s", "--sysfs=/host-sysfs", "--kubelet-config-file=/path/testconfig.yaml", "--podresources-socket=/path/testkubelet.sock", "--ca-file=ca", "--cert-file=crt", "--key-file=key"})
+			args, finderArgs, err := argsParse([]string{"--no-publish", "--sleep-interval=30s", "--sysfs=/host/sysfs-root", "--kubelet-config-file=/path/testconfig.yaml", "--podresources-socket=/path/testkubelet.sock", "--ca-file=ca", "--cert-file=crt", "--key-file=key"})
 
 			Convey("--no-publish is set and args.sources is set to appropriate values", func() {
 				So(args.NoPublish, ShouldBeTrue)
@@ -89,7 +89,7 @@ func TestArgsParse(t *testing.T) {
 				So(args.CertFile, ShouldEqual, "crt")
 				So(args.KeyFile, ShouldEqual, "key")
 				So(finderArgs.SleepInterval, ShouldEqual, 30*time.Second)
-				So(finderArgs.SysfsRoot, ShouldEqual, "/host-sysfs")
+				So(finderArgs.SysfsRoot, ShouldEqual, "/host/sysfs-root")
 				So(finderArgs.KubeletConfigFile, ShouldEqual, "/path/testconfig.yaml")
 				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/path/testkubelet.sock")
 				So(err, ShouldBeNil)

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.14
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
-	github.com/fromanirh/topologyinfo v0.0.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.3
+	github.com/jaypipes/ghw v0.6.1
 	github.com/klauspost/cpuid v1.2.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
@@ -62,3 +62,5 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.20.0-beta.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.0-beta.2
 )
+
+replace github.com/jaypipes/ghw v0.6.1 => github.com/fromanirh/ghw v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -218,14 +220,12 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
-github.com/fromanirh/cpuset v0.0.0-20200530094055-76ce61745438 h1:MPtmR7mE71JGqkiaC2vRR+rW53FgHWLNiI3yvFaJRK8=
-github.com/fromanirh/cpuset v0.0.0-20200530094055-76ce61745438/go.mod h1:9lEAgXAusbccWNAvnt81P76p0g+dCgm1AR91DlpDgy0=
+github.com/fromanirh/ghw v0.0.3 h1:J3UbCrlrIf4sNpWoF1aasijFnSu/TOC7jmBP6f1zpfI=
+github.com/fromanirh/ghw v0.0.3/go.mod h1:QOXppNRCLGYR1H+hu09FxZPqjNt09bqUZUnOL3Rcero=
 github.com/fromanirh/kubernetes v1.18.0-alpha.1.0.20201127133213-6f0bc0d851ab h1:moI7z14IkqFnClt0DP9M7pcYlY/8f/r/lrhcaBD5aQU=
 github.com/fromanirh/kubernetes v1.18.0-alpha.1.0.20201127133213-6f0bc0d851ab/go.mod h1:/xrHGNfoQphtkhZvyd5bA1lRmz+QkDVmBZu+O8QMoek=
 github.com/fromanirh/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20201127133213-6f0bc0d851ab h1:t6dvIjya+kryw71YUtVVWcgEnzu8NPltLUp9wvMKPa0=
 github.com/fromanirh/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20201127133213-6f0bc0d851ab/go.mod h1:B80sNAi0WQAEMuil1AWJk58uBTWbeaB2rpalid8bwVA=
-github.com/fromanirh/topologyinfo v0.0.1 h1:ZujC2PDbBv/5m2uqISv17RKLceW9ENwEWaQpjO2wiLE=
-github.com/fromanirh/topologyinfo v0.0.1/go.mod h1:yPJWY6Nhjaj7LcUFi1bpOGgsKM4euCqGhirrcUEJCDk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -247,6 +247,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
+github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -421,6 +423,9 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
+github.com/jaypipes/pcidb v0.5.0 h1:4W5gZ+G7QxydevI8/MmmKdnIPJpURqJ2JNXTzfLxF5c=
+github.com/jaypipes/pcidb v0.5.0/go.mod h1:L2RGk04sfRhp5wvHO0gfRAMoLY/F3PKv/nwJeVoho0o=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -498,6 +503,7 @@ github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible h1
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
@@ -642,6 +648,7 @@ github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmq
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -1016,6 +1023,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb h1:jhnBjNi9UFpfpl8YZhA9CrOqpnJdvzuiHsl/dnxl11M=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.20.0-beta.2 h1:ewQV7HgnW2oOahBQJsr0R1/ET1SyEWqirjm5QLHfzx0=
 k8s.io/api v0.20.0-beta.2/go.mod h1:GYLMpsvdRvB+u1feyZEqein68bklcyxaFnDYCvdHeJI=
 k8s.io/apiextensions-apiserver v0.20.0-beta.2 h1:wKupCDeTELXwplHwDnYkvqvNt9YZiKfWAYPglBYcplY=

--- a/manifests/nfd-daemonset-combined.yaml.template
+++ b/manifests/nfd-daemonset-combined.yaml.template
@@ -152,7 +152,7 @@ spec:
             - name: kubelet-podresources-sock
               mountPath: /podresources/kubelet.sock
             - name: host-sys
-              mountPath: /host-sys
+              mountPath: /host/sys
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"

--- a/manifests/nfd-daemonset-master-topology-updater.yaml.template
+++ b/manifests/nfd-daemonset-master-topology-updater.yaml.template
@@ -119,7 +119,7 @@ spec:
             - name: kubelet-podresources-sock
               mountPath: /podresources/kubelet.sock
             - name: host-sys
-              mountPath: /host-sys
+              mountPath: /host/sys
       ## Enable TLS authentication (2/3)
       #            - name: nfd-ca-cert
       #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"

--- a/manifests/nfd-daemonset-master-worker.yaml.template
+++ b/manifests/nfd-daemonset-master-worker.yaml.template
@@ -102,7 +102,7 @@ spec:
               mountPath: "/host-etc/os-release"
               readOnly: true
             - name: host-sys
-              mountPath: "/host-sys"
+              mountPath: "/host/sys"
               readOnly: true
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"

--- a/manifests/nfd-topology-updater-daemonset.yaml.template
+++ b/manifests/nfd-topology-updater-daemonset.yaml.template
@@ -50,7 +50,7 @@ spec:
             - name: kubelet-podresources-sock
               mountPath: /podresources/kubelet.sock
             - name: host-sysfs
-              mountPath: /host-sys
+              mountPath: /host/sys
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"

--- a/manifests/nfd-topology-updater-job.yaml.template
+++ b/manifests/nfd-topology-updater-job.yaml.template
@@ -53,7 +53,7 @@ spec:
               mountPath: "/host-etc/os-release"
               readOnly: true
             - name: host-sys
-              mountPath: "/host-sys"
+              mountPath: "/host/sys"
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
             - name: features-d


### PR DESCRIPTION
We can use GHW facilities for everything bar the NUMA distances - which we use to estimate the costs.
So, we fork ghw and augment it to report NUMA distances; we are going to submit the patch to u/s asap.
Meantime, we consume the fork to further validate it.

Signed-off-by: Francesco Romani <fromani@redhat.com>