### PR TITLE
makeResourceMap: Update resource map appropriately

### DIFF
--- a/pkg/resourcemonitor/noderesourcesaggregator.go
+++ b/pkg/resourcemonitor/noderesourcesaggregator.go
@@ -217,7 +217,7 @@ func MakeNodeCapacity(devices []*podresourcesapi.ContainerDevices) map[int]map[v
 			if !ok {
 				nodeRes = make(map[v1.ResourceName]int64)
 			}
-			nodeRes[v1.ResourceName(resourceName)] = int64(len(device.GetDeviceIds()))
+			nodeRes[v1.ResourceName(resourceName)] += int64(len(device.GetDeviceIds()))
 			perNUMACapacity[nodeNum] = nodeRes
 		}
 	}
@@ -231,14 +231,17 @@ func makeResourceMap(numaNodes int, devices []*podresourcesapi.ContainerDevices)
 	resourceMap := make(map[string]map[string]int)
 
 	for _, device := range devices {
-		deviceID2NUMAID := make(map[string]int)
+		resourceName := device.GetResourceName()
+		_, ok := resourceMap[resourceName]
+		if !ok {
+			resourceMap[resourceName] = make(map[string]int)
+		}
 		for _, node := range device.GetTopology().GetNodes() {
 			nodeNuma := int(node.GetID())
 			for _, deviceID := range device.GetDeviceIds() {
-				deviceID2NUMAID[deviceID] = nodeNuma
+				resourceMap[resourceName][deviceID] = nodeNuma
 			}
 		}
-		resourceMap[device.GetResourceName()] = deviceID2NUMAID
 	}
 	return resourceMap
 }


### PR DESCRIPTION
- resource map is mapping from resourcename -> deviceID -> numa node
- We loop through all the devices and group them on the basis
  of their resourcename (e.g. example.com/deviceA or cpu)
- If a new resourcename is identified (e.g. example.com/deviceB),
  then we need to create a new map of type map[string]int to store
  the mapping from deviceId to numanodes of all the devices belonging
  to that resourceName type.
- For example, this patch makes sure that the resourceMap is populated as follows:
  map[example.com/deviceA:map[DevA1:1 DevA2:0 DevA3:1 DevA4:0]
  example.com/deviceB:map[DevB1:1 DevB2:0 DevB3:1 DevB4:0]]

  whereas previous implmentation leads to creation of a new map[string]int for each device
  storing the information as follows:
  Initially resourceName = map[example.com/deviceA:map[DevA1:1]] which gets overwritten
  in the subsequent iterations finally ending up with something like below:
  map[example.com/deviceA:map[DevA4:0]example.com/deviceB:map[DevB4:0]]
  and hence resulting to incorrect decrementing of devices in updateAllocatable()
  and subsequently leading to erroneous accounting of resources per numa nodes

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>