### PR TITLE
Update the default image registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ JEKYLL_OPTS := -d '$(SITE_DESTDIR)' $(if $(SITE_BASEURL),-b '$(SITE_BASEURL)',)
 
 VERSION := $(shell git describe --tags --dirty --always)
 
-IMAGE_REGISTRY ?= quay.io/swsehgal
+IMAGE_REGISTRY ?= k8s.gcr.io/nfd
 IMAGE_TAG_NAME ?= $(VERSION)
 IMAGE_EXTRA_TAG_NAMES ?=
 


### PR DESCRIPTION
 - keep it same as the one used in NFD
 - quay.io/swsehgal -> k8s.gcr.io/nfd

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>