### PR TITLE
go: mod: track again upstream ghw

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.3
-	github.com/jaypipes/ghw v0.6.1
+	github.com/jaypipes/ghw v0.6.2-0.20210115144335-efbe6fd4efca
 	github.com/klauspost/cpuid v1.2.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
@@ -65,5 +65,3 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.20.0-beta.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.0-beta.2
 )
-
-replace github.com/jaypipes/ghw v0.6.1 => github.com/fromanirh/ghw v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -423,6 +423,9 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
+github.com/jaypipes/ghw v0.6.1/go.mod h1:QOXppNRCLGYR1H+hu09FxZPqjNt09bqUZUnOL3Rcero=
+github.com/jaypipes/ghw v0.6.2-0.20210115144335-efbe6fd4efca h1:pJpwCf7qq33TyKpc39RJzRSWeIntvFPEYPeVlJrOTvc=
+github.com/jaypipes/ghw v0.6.2-0.20210115144335-efbe6fd4efca/go.mod h1:QOXppNRCLGYR1H+hu09FxZPqjNt09bqUZUnOL3Rcero=
 github.com/jaypipes/pcidb v0.5.0 h1:4W5gZ+G7QxydevI8/MmmKdnIPJpURqJ2JNXTzfLxF5c=
 github.com/jaypipes/pcidb v0.5.0/go.mod h1:L2RGk04sfRhp5wvHO0gfRAMoLY/F3PKv/nwJeVoho0o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
all the patches relevant to RTE have been merged to upstream ghw,
so there is no longer need to track fromani's fork.

Signed-off-by: Francesco Romani <fromani@redhat.com>